### PR TITLE
refactor: remove PAT support and simplify popup UI

### DIFF
--- a/entrypoints/github-commits-page.content.ts
+++ b/entrypoints/github-commits-page.content.ts
@@ -1,7 +1,7 @@
 /**
  * MAIN world content script: runs in the page's JavaScript context.
  * This allows fetch() calls to include GitHub's session cookies,
- * enabling tag data retrieval without a Personal Access Token.
+ * enabling tag data retrieval using session cookies.
  */
 export default defineContentScript({
   matches: ['https://github.com/*/*/commits/*'],

--- a/entrypoints/github-commits.content.ts
+++ b/entrypoints/github-commits.content.ts
@@ -97,8 +97,7 @@ function injectBadges(row: HTMLElement, tags: string[], owner: string, repo: str
 
 /**
  * Request tag data from the MAIN world content script via postMessage.
- * The MAIN world script fetches GitHub's /tags pages with session cookies,
- * so no PAT is required for logged-in users.
+ * The MAIN world script fetches GitHub's /tags pages with session cookies.
  */
 function fetchTagsViaPageContext(
   owner: string,
@@ -150,14 +149,14 @@ async function processCommits(): Promise<void> {
     if (cached) {
       tagMap = filterByShas(cached, shas);
     } else {
-      // 2. Try page-context fetch (no PAT needed, uses session cookies)
+      // 2. Try page-context fetch (uses session cookies)
       const pageResult = await fetchTagsViaPageContext(owner, repo);
       if (pageResult && Object.keys(pageResult).length > 0) {
         // Cache the full tag map for subsequent navigations
         sendMessage('cacheTagMap', { owner, repo, tagMap: pageResult }).catch(() => {});
         tagMap = filterByShas(pageResult, shas);
       } else {
-        // 3. Fallback to REST API via background (with optional PAT)
+        // 3. Fallback to REST API via background
         tagMap = await sendMessage('getTagsForCommits', { owner, repo, shas });
       }
     }

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -11,34 +11,10 @@
       <h1>CommitTagger</h1>
 
       <section>
-        <h2>GitHub Token (Optional)</h2>
-        <p class="hint">
-          CommitTagger works without a token for logged-in GitHub users by fetching tag data
-          directly from the page context. A PAT is only needed as a fallback (increases rate
-          limit from 60 to 5,000 requests/hour). No scopes required for public repos.
-        </p>
-        <div class="input-group">
-          <input
-            type="password"
-            id="token-input"
-            placeholder="ghp_xxxxxxxxxxxx"
-            autocomplete="off"
-          />
-          <button id="save-token">Save</button>
-        </div>
-        <div id="token-status" class="status"></div>
-      </section>
-
-      <section>
         <h2>Cache</h2>
         <p class="hint">Tag data is cached for 1 hour to reduce API calls.</p>
         <button id="clear-cache" class="secondary">Clear All Cache</button>
         <div id="cache-status" class="status"></div>
-      </section>
-
-      <section>
-        <h2>Rate Limit</h2>
-        <div id="rate-info" class="rate-info">Loading...</div>
       </section>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -1,38 +1,7 @@
-import { TOKEN_STORAGE_KEY, GITHUB_API_BASE } from '~/utils/constants';
 import { clearAllCaches } from '~/utils/cache';
 
-const tokenInput = document.getElementById('token-input') as HTMLInputElement;
-const saveTokenBtn = document.getElementById('save-token') as HTMLButtonElement;
-const tokenStatus = document.getElementById('token-status') as HTMLDivElement;
 const clearCacheBtn = document.getElementById('clear-cache') as HTMLButtonElement;
 const cacheStatus = document.getElementById('cache-status') as HTMLDivElement;
-const rateInfo = document.getElementById('rate-info') as HTMLDivElement;
-
-// Load existing token on popup open
-async function loadToken(): Promise<void> {
-  const result = await chrome.storage.local.get(TOKEN_STORAGE_KEY);
-  const token = result[TOKEN_STORAGE_KEY];
-  if (token) {
-    tokenInput.value = token;
-    tokenStatus.textContent = 'Token is set';
-    tokenStatus.className = 'status success';
-  }
-}
-
-// Save token
-saveTokenBtn.addEventListener('click', async () => {
-  const token = tokenInput.value.trim();
-  if (token) {
-    await chrome.storage.local.set({ [TOKEN_STORAGE_KEY]: token });
-    tokenStatus.textContent = 'Token saved!';
-    tokenStatus.className = 'status success';
-  } else {
-    await chrome.storage.local.remove(TOKEN_STORAGE_KEY);
-    tokenStatus.textContent = 'Token removed';
-    tokenStatus.className = 'status';
-  }
-  await fetchRateLimit();
-});
 
 // Clear cache
 clearCacheBtn.addEventListener('click', async () => {
@@ -43,40 +12,3 @@ clearCacheBtn.addEventListener('click', async () => {
     cacheStatus.textContent = '';
   }, 2000);
 });
-
-// Fetch and display rate limit info
-async function fetchRateLimit(): Promise<void> {
-  try {
-    const result = await chrome.storage.local.get(TOKEN_STORAGE_KEY);
-    const token = result[TOKEN_STORAGE_KEY];
-
-    const headers: Record<string, string> = {
-      Accept: 'application/vnd.github.v3+json',
-    };
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-
-    const response = await fetch(`${GITHUB_API_BASE}/rate_limit`, { headers });
-
-    if (!response.ok) {
-      rateInfo.textContent = 'Failed to fetch rate limit';
-      return;
-    }
-
-    const data = await response.json();
-    const core = data.resources.core;
-    const resetDate = new Date(core.reset * 1000);
-    const resetStr = resetDate.toLocaleTimeString();
-
-    rateInfo.innerHTML =
-      `<strong>${core.remaining}</strong> / ${core.limit} requests remaining<br>` +
-      `Resets at ${resetStr}`;
-  } catch {
-    rateInfo.textContent = 'Unable to check rate limit';
-  }
-}
-
-// Initialize
-loadToken();
-fetchRateLimit();

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -41,26 +41,6 @@ section {
   line-height: 1.4;
 }
 
-.input-group {
-  display: flex;
-  gap: 6px;
-}
-
-input[type='password'] {
-  flex: 1;
-  padding: 5px 8px;
-  border: 1px solid #d0d7de;
-  border-radius: 6px;
-  font-size: 12px;
-  font-family: monospace;
-  outline: none;
-}
-
-input[type='password']:focus {
-  border-color: #0969da;
-  box-shadow: 0 0 0 3px rgba(9, 105, 218, 0.12);
-}
-
 button {
   padding: 5px 12px;
   font-size: 12px;
@@ -98,12 +78,3 @@ button.secondary:hover {
   color: #1a7f37;
 }
 
-.rate-info {
-  font-size: 12px;
-  color: #656d76;
-  line-height: 1.5;
-}
-
-.rate-info strong {
-  color: #24292f;
-}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "commit-tagger",
   "description": "Display tags on GitHub commit list pages",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -16,9 +16,6 @@ export const COMMIT_LINK_SELECTOR = 'a[href*="/commit/"]';
 /** GitHub API tags per page (max 100) */
 export const TAGS_PER_PAGE = 100;
 
-/** Storage key for GitHub PAT */
-export const TOKEN_STORAGE_KEY = 'github_pat';
-
 /** Prefix for cache storage keys */
 export const CACHE_KEY_PREFIX = 'tag_cache_';
 


### PR DESCRIPTION
## Summary
- PAT(Personal Access Token)設定UI、Rate Limit表示、関連コードを削除
- ページコンテキスト取得(セッションCookie利用)が主要手段のため、PAT不要
- ポップアップをキャッシュクリア機能のみにシンプル化
- バージョンを1.2.0に更新

## Test plan
- [ ] ポップアップにToken設定・Rate Limit表示が表示されないこと
- [ ] キャッシュクリアボタンが正常に動作すること
- [ ] GitHubのcommitsページでタグバッジが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)